### PR TITLE
fix: 캐러셀 내부 텍스트 콘텐츠 디자인 일치화

### DIFF
--- a/app/components/common/carousel/tile.tsx
+++ b/app/components/common/carousel/tile.tsx
@@ -31,7 +31,7 @@ export default function Tile({
           />
         </figure>
         <div className="pt-[10px] flex flex-col items-between">
-          <div className="h-12 w-40 font-bold truncate">
+          <div className="h-12 w-[150px] font-bold truncate">
             <h4>{name}</h4>
             <p className="pt-1 truncate">{description}</p>
           </div>

--- a/app/components/common/hero/hero-tile.tsx
+++ b/app/components/common/hero/hero-tile.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 
 export default function HeroTile({
   id,
+  addr,
   name,
   startdate,
   enddate,
@@ -32,13 +33,14 @@ export default function HeroTile({
         <div className="absolute bottom-0 left-0 right-0 top-0 bg-gradient-hero-carousel" />
       </div>
 
-      <div className="absolute bottom-[-16px] left-5 flex h-1/3 gap-y-1.5 flex-col rounded-2xl text-white">
-        <div className="flex flex-col text-xl font-semibold gap-1.5">
-          <h4>{name}</h4>
-          <span>{description}</span>
-        </div>
-        <div className="flex text-sm font-semibold">
-          <span>{formatDate(startdate, enddate, 'ko')}</span>
+      <div className="absolute bottom-[60px] left-5 right-[74px] flex h-[114px] gap-y-1.5 flex-col text-white">
+        <div className="text-xl font-semibold">
+          <span className='mt-[3px] text-xs leading-[18px] tracking-[-0.36px]'>{addr}</span>
+          <h4 className='font-bold text-[22px] leading-[33px] tracking-[-0.66px]'>{name}</h4>
+          <span className='block text-xl leading-[30px] tracking-[-0.6px] truncate'>{description}</span>
+          <span className='mt-[6px] text-sm tracking-[-0.42px]'>
+            {formatDate(startdate, enddate, 'ko')}
+          </span>
         </div>
       </div>
     </Link>

--- a/app/components/common/hero/hero-tile.tsx
+++ b/app/components/common/hero/hero-tile.tsx
@@ -12,7 +12,6 @@ export default function HeroTile({
   enddate,
   description,
   festivalimage,
-  url,
   priority = false,
 }: FestivalInfo & { priority?: boolean }) {
   return (
@@ -33,15 +32,13 @@ export default function HeroTile({
         <div className="absolute bottom-0 left-0 right-0 top-0 bg-gradient-hero-carousel" />
       </div>
 
-      <div className="absolute bottom-[60px] left-5 right-[74px] flex h-[114px] gap-y-1.5 flex-col text-white">
-        <div className="text-xl font-semibold">
-          <span className='mt-[3px] text-xs leading-[18px] tracking-[-0.36px]'>{addr}</span>
-          <h4 className='font-bold text-[22px] leading-[33px] tracking-[-0.66px]'>{name}</h4>
-          <span className='block text-xl leading-[30px] tracking-[-0.6px] truncate'>{description}</span>
-          <span className='mt-[6px] text-sm tracking-[-0.42px]'>
-            {formatDate(startdate, enddate, 'ko')}
-          </span>
-        </div>
+      <div className="absolute bottom-[60px] left-5 right-[74px] h-[114px] text-xl font-semibold">
+        <span className='mt-[3px] text-xs leading-[18px] tracking-[-0.36px]'>{addr}</span>
+        <h4 className='font-bold text-[22px] leading-[33px] tracking-[-0.66px]'>{name}</h4>
+        <span className='block leading-[30px] tracking-[-0.6px] truncate'>{description}</span>
+        <span className='mt-[6px] text-sm tracking-[-0.42px]'>
+          {formatDate(startdate, enddate, 'ko')}
+        </span>
       </div>
     </Link>
   );

--- a/app/components/common/navigation/index.tsx
+++ b/app/components/common/navigation/index.tsx
@@ -20,7 +20,7 @@ export default function Navigation({ title, variant }: Props) {
         <>
           <LogoLink />
           <Link href="#" className="w-auto h-auto flex items-center">
-            <Magnifier fill="white" />
+            <Magnifier className="scale-90" fill="white" />
           </Link>
         </>
       )}


### PR DESCRIPTION
#26 closed
- [x]  text-overflow시 ...(ellipsis) 처리했습니다. 추후에 어드민에서 descrption 길이 제한이 필요해보입니다.
- [x]  검색 아이콘 scale(0.9)
- [x]  addr 정보 추가
- [x] carousel tile - description부분 width 수정

![스크린샷 2024-05-19 02-09-04](https://github.com/ToyVallet/swifty-fe/assets/55472696/2f8a7d8c-3c8a-458b-bd80-fbf6b7e2a1e5)
